### PR TITLE
Add support for Request:peer_ip/0 and Request:peer_port/0 for webmachine

### DIFF
--- a/src/webmachine_bridge_modules/webmachine_request_bridge.erl
+++ b/src/webmachine_bridge_modules/webmachine_request_bridge.erl
@@ -36,11 +36,12 @@ uri(Req) ->
     {_, QueryString, _} = mochiweb_util:urlsplit_path(RawPath),
     QueryString.
 
-peer_ip(_Req) -> 
-    throw(unsupported).
+peer_ip(Req) ->
+    {ok, Address} = inet_parse:address(wrq:peer(Req)),
+    Address.
 
-peer_port(_Req) -> 
-    throw(unsupported).
+peer_port(Req) ->
+    wrq:port(Req).
 
 headers(Req) ->
     F = fun(Header) -> wrq:get_req_header(Header, Req) end,


### PR DESCRIPTION
Hello

Here's a small patch to add support for peer_ip and peer_port to Webmachine request bridge.

Best regards,
Gleb Peregud
