### PR TITLE
uri/1 should return full url with qureysrting

### DIFF
--- a/src/webmachine_bridge_modules/webmachine_request_bridge.erl
+++ b/src/webmachine_bridge_modules/webmachine_request_bridge.erl
@@ -32,9 +32,7 @@ path(Req) ->
     wrq:path(Req).
 
 uri(Req) -> 
-    RawPath = wrq:raw_path(Req),
-    {_, QueryString, _} = mochiweb_util:urlsplit_path(RawPath),
-    QueryString.
+    wrq:raw_path(Req).
 
 peer_ip(Req) ->
     {ok, Address} = inet_parse:address(wrq:peer(Req)),


### PR DESCRIPTION
according to https://github.com/nitrogen/simple_bridge/blob/master/src/simple_bridge_request.erl
uri/1 is "The uri (path and querystring)"
