### PR TITLE
New Req:protocol() -> http | https

### DIFF
--- a/src/cowboy_bridge_modules/cowboy_request_bridge.erl
+++ b/src/cowboy_bridge_modules/cowboy_request_bridge.erl
@@ -9,7 +9,7 @@
 
 -export ([
     init/1,
-    request_method/1, path/1, uri/1,
+    protocol/1, request_method/1, path/1, uri/1,
     peer_ip/1, peer_port/1,
     headers/1, cookies/1,
     query_params/1, post_params/1, request_body/1,
@@ -31,6 +31,8 @@ init({Req,DocRoot}) ->
     },
     ?PUT,
     ReqKey.
+
+protocol(_ReqKey) -> undefined.
 
 request_method(ReqKey) ->
     ?GET,

--- a/src/inets_bridge_modules/inets_request_bridge.erl
+++ b/src/inets_bridge_modules/inets_request_bridge.erl
@@ -8,7 +8,7 @@
 -include_lib ("simple_bridge.hrl").
 -export ([
     init/1,
-    request_method/1, path/1, uri/1,
+    protocol/1, request_method/1, path/1, uri/1,
     peer_ip/1, peer_port/1,
     headers/1, cookies/1,
     query_params/1, post_params/1, request_body/1,
@@ -18,6 +18,12 @@
 
 init(Req) -> 
     Req.
+
+protocol(Req) ->
+    case Req#mod.socket of
+        S when is_tuple(S), element(1, S) =:= sslsocket -> https;
+        _ -> http
+    end.
 
 request_method(Req) -> 
     list_to_atom(Req#mod.method).

--- a/src/misultin_bridge_modules/misultin_request_bridge.erl
+++ b/src/misultin_bridge_modules/misultin_request_bridge.erl
@@ -3,7 +3,7 @@
 -include_lib ("simple_bridge.hrl").
 -export ([
     init/1,
-    request_method/1, path/1, uri/1,
+    protocol/1, request_method/1, path/1, uri/1,
     peer_ip/1, peer_port/1,
     headers/1, header/2, cookies/1,
     query_params/1, post_params/1, request_body/1,
@@ -12,6 +12,8 @@
 
 init(Req) -> 
     Req.
+
+protocol(_Req) -> undefined.
 
 request_method(Req) -> 
     Req:get(method).

--- a/src/mochiweb_bridge_modules/mochiweb_request_bridge.erl
+++ b/src/mochiweb_bridge_modules/mochiweb_request_bridge.erl
@@ -8,7 +8,7 @@
 -include_lib ("simple_bridge.hrl").
 -export ([
     init/1,
-    request_method/1, path/1, uri/1,
+    protocol/1, request_method/1, path/1, uri/1,
     peer_ip/1, peer_port/1,
     headers/1, header/2, cookies/1,
     query_params/1, post_params/1, request_body/1,
@@ -24,6 +24,9 @@ init({Req, _DocRoot}) ->
     init(Req);
 init(Req) -> 
     Req.
+
+protocol(Req) ->
+    Req:get(scheme).
 
 request_method(Req) -> 
     Req:get(method).

--- a/src/simple_bridge_request.erl
+++ b/src/simple_bridge_request.erl
@@ -34,6 +34,7 @@ make_nocatch(Module, RequestData) ->
 behaviour_info(callbacks) -> [
     {init, 1},           % Should accept the request value passed by the http server.
 
+    {protocol, 1},       % http | https | undefined
     {request_method, 1}, % GET, POST, etc.
     {uri, 1},            % The uri (path and querystring)
     {path, 1},           % Just the path. (http://server.com/<PATH>?querystring)

--- a/src/simple_bridge_request_wrapper.erl
+++ b/src/simple_bridge_request_wrapper.erl
@@ -12,6 +12,7 @@ set_multipart(PostParams1, PostFiles1) ->
 set_error(Error1) ->
     simple_bridge_request_wrapper:new(Mod, Req, true, PostParams, PostFiles, Error1).
 
+protocol() -> Mod:protocol(Req).
 request_method() -> Mod:request_method(Req).
 path() -> Mod:path(Req).
 uri() -> Mod:uri(Req).

--- a/src/webmachine_bridge_modules/webmachine_request_bridge.erl
+++ b/src/webmachine_bridge_modules/webmachine_request_bridge.erl
@@ -8,6 +8,7 @@
 
 -export ([
     init/1,
+    protocol/1,
     request_method/1, 
     path/1, 
     uri/1,
@@ -24,6 +25,8 @@
 
 init(Req) -> 
     Req.
+
+protocol(_Req) -> undefined.
 
 request_method(Req) -> 
     wrq:method(Req).

--- a/src/yaws_bridge_modules/yaws_request_bridge.erl
+++ b/src/yaws_bridge_modules/yaws_request_bridge.erl
@@ -6,7 +6,7 @@
 -include_lib ("simple_bridge.hrl").
 -export ([
     init/1,
-    request_method/1, path/1, uri/1,
+    request_method/1, protocol/1, path/1, uri/1,
     peer_ip/1, peer_port/1,
     headers/1, cookie/2, cookies/1,
     query_params/1, post_params/1, request_body/1,
@@ -15,6 +15,8 @@
 
 init(Req) ->
     Req.
+
+protocol(_Arg) -> undefined.
 
 request_method(Arg) ->
     yaws_api:http_request_method(yaws_api:arg_req(Arg)).


### PR DESCRIPTION
Includes support for inets and mochiweb, but not others.
