### PR TITLE
Add dash to deep params parser regexp

### DIFF
--- a/src/simple_bridge_request_wrapper.erl
+++ b/src/simple_bridge_request_wrapper.erl
@@ -117,7 +117,7 @@ find_deep_post_param([Index|Rest], Params) when is_list(Index) ->
 parse_deep_post_params([], Acc) ->
     Acc;
 parse_deep_post_params([{Key, Value}|Rest], Acc) ->
-    case re:run(Key, "^(\\w+)(?:\\[([\\w\\[\\]]+)\\])?$", [{capture, all_but_first, list}]) of
+    case re:run(Key, "^(\\w+)(?:\\[([\\w-\\[\\]]+)\\])?$", [{capture, all_but_first, list}]) of
         {match, [Key]} ->
             parse_deep_post_params(Rest, [{Key, Value}|Acc]);
         {match, [KeyName, Path]} ->


### PR DESCRIPTION
I needed to use dash in element name in deep post params and this is fix to make it work. Perhaps someone could use it too. :)
