### PR TITLE
Update cowboy_simple_bridge_anchor.erl

### DIFF
--- a/src/cowboy_bridge_modules/cowboy_simple_bridge_anchor.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge_anchor.erl
@@ -82,9 +82,9 @@ websocket_terminate(Reason, _Req, #ws_state{bridge=Bridge, handler=Handler, stat
 %% be handled by cowboy.
 massage_reply({reply, {Type, Data}, NewState}, Req, WSState)
         when Type==binary orelse Type==text ->
-    {reply, {Type, iolist_to_binary(Data)}, Req, WSState#ws_state{state=NewState}};
+    {reply, {Type, unicode:characters_to_binary(Data)}, Req, WSState#ws_state{state=NewState}};
 massage_reply({reply, List, NewState}, Req, WSState) ->
-    FixedList = [{Type, iolist_to_binary(Data)} || {Type, Data} <- List],
+    FixedList = [{Type, unicode:characters_to_binary(Data)} || {Type, Data} <- List],
     {reply, FixedList, Req, WSState#ws_state{state=NewState}};
 massage_reply({reply, Reply}, Req, WSState) ->
     massage_reply({reply, Reply, WSState#ws_state.state}, Req, WSState);


### PR DESCRIPTION
 erlang:iolist_to_binary/1 can't work for utf8,  instead of it with unicode:characters_to_binary/1