### PR TITLE
YAWs Timeout and max file post size

### DIFF
--- a/etc/simple_bridge.config
+++ b/etc/simple_bridge.config
@@ -60,6 +60,15 @@
         %% be placed.
 
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        %% BACKEND-CONFIG
+        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        {websocket_interval, 10000}
+        % Websocket check if socket is there (milliseconds). Default is 10000 
+        {websocket_timeout, 5000}
+        %% Weboscket timeout (milliseconds) Default is 5000
+
+
+        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
         %% BACKEND-SPECIFIC DISPATCH TABLES:
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/rebar_deps/yaws.deps
+++ b/rebar_deps/yaws.deps
@@ -1,1 +1,1 @@
-    {yaws, "2.*", {git, "git://github.com/klacke/yaws",	{tag, "yaws-2.0"}}}
+    {yaws, "1.*", {git, "git://github.com/klacke/yaws",	{tag, "yaws-1.99"}}}

--- a/rebar_deps/yaws.deps
+++ b/rebar_deps/yaws.deps
@@ -1,1 +1,1 @@
-    {yaws, "1.*", {git, "git://github.com/klacke/yaws",	{tag, "yaws-1.98"}}}
+    {yaws, "2.*", {git, "git://github.com/klacke/yaws",	{tag, "yaws-2.0"}}}

--- a/rebar_deps/yaws.deps
+++ b/rebar_deps/yaws.deps
@@ -1,1 +1,1 @@
-    {yaws, "1.*", {git, "git://github.com/klacke/yaws",	{tag, "yaws-1.99"}}}
+    {yaws, "1.*", {git, "git://github.com/klacke/yaws",	{tag, "yaws-1.98"}}}

--- a/src/yaws_bridge_modules/yaws_simple_bridge_sup.erl
+++ b/src/yaws_bridge_modules/yaws_simple_bridge_sup.erl
@@ -40,8 +40,8 @@ start_embedded_yaws() ->
     RealAddress = simple_bridge_util:parse_ip(Address),
     Servername = simple_bridge_util:to_list(simple_bridge_util:get_server_name(yaws)),
     Anchor = simple_bridge_util:get_anchor_module(yaws),
-	%% Max post is in MB but yaws wants bytes
-	MaxPost = simple_bridge_util:get_max_post_size(yaws) * 1048576,
+    %% Max post is in MB but yaws wants bytes
+    MaxPost = simple_bridge_util:get_max_post_size(yaws) * 1048576,
     ExcludePaths = [filename:split(P) || P <- StaticPaths],
     Appmods = [{"/", Anchor, ExcludePaths}],
 

--- a/src/yaws_bridge_modules/yaws_simple_bridge_sup.erl
+++ b/src/yaws_bridge_modules/yaws_simple_bridge_sup.erl
@@ -36,9 +36,12 @@ init([]) ->
 start_embedded_yaws() ->
     {DocRoot, StaticPaths} = simple_bridge_util:get_docroot_and_static_paths(yaws),
     {Address, Port} = simple_bridge_util:get_address_and_port(yaws),
+	{_KeepAliveInterval, Timeout} =  simple_bridge_util:get_websocket_keepalive_interval_timeout(yaws),
     RealAddress = simple_bridge_util:parse_ip(Address),
     Servername = simple_bridge_util:to_list(simple_bridge_util:get_server_name(yaws)),
     Anchor = simple_bridge_util:get_anchor_module(yaws),
+	%% Max post is in MB but yaws wants bytes
+	MaxPost = simple_bridge_util:get_max_post_size(yaws) * 1048576,
     ExcludePaths = [filename:split(P) || P <- StaticPaths],
     Appmods = [{"/", Anchor, ExcludePaths}],
 
@@ -48,11 +51,13 @@ start_embedded_yaws() ->
         {listen, RealAddress},
         {port, Port},
         {allowed_scripts, []},
+		{partial_post_size, MaxPost},
         {index_files, ["index.html"]},
         {appmods, Appmods}
     ],
 
-    GConf = [{id, Servername}],
+    GConf = [{id, Servername},
+			 {keepalive_timeout, Timeout}],
     io:format("Starting Yaws Server at ~s:~p~n", [Address, Port]),
     io:format("Static Paths: ~p~nDocument Root for Static: ~s~n", [StaticPaths, DocRoot]),
     yaws:start_embedded(DocRoot, SConf, GConf, Servername).

--- a/src/yaws_bridge_modules/yaws_simple_bridge_sup.erl
+++ b/src/yaws_bridge_modules/yaws_simple_bridge_sup.erl
@@ -51,13 +51,13 @@ start_embedded_yaws() ->
         {listen, RealAddress},
         {port, Port},
         {allowed_scripts, []},
-		{partial_post_size, MaxPost},
+        {partial_post_size, MaxPost},
         {index_files, ["index.html"]},
         {appmods, Appmods}
     ],
 
     GConf = [{id, Servername},
-			 {keepalive_timeout, Timeout}],
+             {keepalive_timeout, Timeout}],
     io:format("Starting Yaws Server at ~s:~p~n", [Address, Port]),
     io:format("Static Paths: ~p~nDocument Root for Static: ~s~n", [StaticPaths, DocRoot]),
     yaws:start_embedded(DocRoot, SConf, GConf, Servername).


### PR DESCRIPTION
Hi Jesse,

This is for YAWS using embedded.

This is to allow the max file post size configured in the configuration; to be also applied to yaws otherwise yaws default limits apply; therefore with simple bridge configuration (max_post_size) is not effective at larger values.

Additionally am using the websocket timeout value to set the keepalive_timeout of YAWS. On slower connections you will not receive uploads due to the default of 30 seconds. Going through this I think in the future this should be a different configuration value. 


Added some basic comments to explain there is configuration of websocket_interval and websocket_timeout

Regards,
Stuart
 