### PR TITLE
mostly cowboy issues

### DIFF
--- a/src/cowboy_bridge_modules/cowboy_simple_bridge_sup.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge_sup.erl
@@ -38,14 +38,9 @@ init([]) ->
         {max_keepalive, 100}
     ],
 
-    Args = [http, 100, [{ip, IP}, {port, Port}], Opts],
-    Restart = permanent,
-    Shutdown = 5000,
-    Type = worker,
-    Modules = [cowboy],
+    cowboy:start_http(http, 100, [{ip, IP}, {port, Port}], Opts),
 
-    ChildSpec = {cowboy, {cowboy, start_http, Args}, Restart, Shutdown, Type, Modules},
-    {ok, { {one_for_one, 5, 10}, [ChildSpec]}}.
+    {ok, { {one_for_one, 5, 10}, []}}.
 
 
 %% @doc Generates the dispatch based on the desired environment

--- a/src/cowboy_bridge_modules/cowboy_simple_bridge_sup.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge_sup.erl
@@ -25,9 +25,10 @@ init([]) ->
     application:start(cowlib),
     application:start(cowboy),
     {Address, Port} = simple_bridge_util:get_address_and_port(cowboy),
+    IP = simple_bridge_util:parse_ip(Address),
 
-    io:format("Starting Cowboy Server on ~s:~p~n",
-              [Address, Port]),
+    io:format("Starting Cowboy Server on ~p:~p~n",
+              [IP, Port]),
 
     Dispatch = generate_dispatch(),
     io:format("Using Cowboy Dispatch Table:~n  ~p~n",[Dispatch]),
@@ -37,7 +38,7 @@ init([]) ->
         {max_keepalive, 100}
     ],
 
-    Args = [http, 100, [{port, Port}], Opts],
+    Args = [http, 100, [{ip, IP}, {port, Port}], Opts],
     Restart = permanent,
     Shutdown = 5000,
     Type = worker,

--- a/src/mochiweb_bridge_modules/mochiweb_simple_bridge_sup.erl
+++ b/src/mochiweb_bridge_modules/mochiweb_simple_bridge_sup.erl
@@ -33,7 +33,7 @@ init([]) ->
 
     Anchor = simple_bridge_util:get_anchor_module(mochiweb),
 
-    io:format("Starting Mochiweb Server on ~s:~p~n", [Address, Port]),
+    io:format("Starting Mochiweb Server on ~p:~p~n", [Address, Port]),
     io:format("Static Paths: ~p~nDocument Root for Static: ~s~n", [StaticPaths, DocRoot]),
 
     % Start Mochiweb...

--- a/src/webmachine_bridge_modules/webmachine_simple_bridge_sup.erl
+++ b/src/webmachine_bridge_modules/webmachine_simple_bridge_sup.erl
@@ -29,7 +29,7 @@ init([]) ->
     {Address, Port} = simple_bridge_util:get_address_and_port(webmachine),
     Dispatch = generate_dispatch(),
 
-    io:format("Starting Webmachine Server on ~s:~p~n", [Address, Port]),
+    io:format("Starting Webmachine Server on ~p:~p~n", [Address, Port]),
 
     Options = [
         {ip, Address}, 

--- a/src/yaws_bridge_modules/yaws_simple_bridge_sup.erl
+++ b/src/yaws_bridge_modules/yaws_simple_bridge_sup.erl
@@ -53,6 +53,6 @@ start_embedded_yaws() ->
     ],
 
     GConf = [{id, Servername}],
-    io:format("Starting Yaws Server at ~s:~p~n", [Address, Port]),
+    io:format("Starting Yaws Server at ~p:~p~n", [Address, Port]),
     io:format("Static Paths: ~p~nDocument Root for Static: ~s~n", [StaticPaths, DocRoot]),
     yaws:start_embedded(DocRoot, SConf, GConf, Servername).


### PR DESCRIPTION
* 'address' setting has been actually ignored for cowboy and server started on all IPs available in any case. 
* ranch accept IP only as tuple, so convert them to such before passing to ranch.
 * allow passing IP as a tuple (for all webservers)
* start cowboy correctly (fixes problem described in ChicagoBoss/ChicagoBoss#614)