### PR TITLE
Cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ test/app.config
 logs/
 rebar.test.*.config
 .deps_plt
+/ebin/
+/.settings/
+/.project

--- a/README.markdown
+++ b/README.markdown
@@ -327,8 +327,14 @@ The Bridge modules export the following functions:
   * **sbw:clear_headers(Bridge)** - clear all previously set headers.
   * **sbw:set_cookie(Name, Value, Bridge)** - set a cookie for path "/" with expiration in
     20 minutes.
-  * **sbw:set_cookie(Name, Value, Path, Exp, Bridge)** - Set a cookie. Exp is an integer
-    in minutes.
+  * **sbw:set_cookie(Name, Value, Options, Bridge)** - set a cookie with an Options list
+  [
+                   {domain, undefined},
+                   {path, "/"},
+                   {max_age, 3600}, %% time in seconds
+                   {secure, false},
+                   {http_only, false}
+                  ]
   * **sbw:clear_cookies(Bridge)** - clear all previously set cookies.
   * **sbw:set_response_data(Data, Bridge)** - set the data to return in the response. Usually HTML
     goes here.

--- a/README.markdown
+++ b/README.markdown
@@ -326,7 +326,7 @@ The Bridge modules export the following functions:
   * **sbw:set_header(Name, Value, Bridge)** - set an HTTP header.
   * **sbw:clear_headers(Bridge)** - clear all previously set headers.
   * **sbw:set_cookie(Name, Value, Bridge)** - set a cookie for path "/" with expiration in
-    20 minutes.
+    1 hour.
   * **sbw:set_cookie(Name, Value, Options, Bridge)** - set a cookie with an Options list
   [
                    {domain, undefined},

--- a/include/simple_bridge.hrl
+++ b/include/simple_bridge.hrl
@@ -6,7 +6,7 @@
 -ifndef(simple_bridge_hrl).
 -define(simple_bridge_hrl, true).
 
--record(cookie, { name, value, path="/", minutes_to_live=20 }).
+-record(cookie, { name, value, domain=undefined, path="/", max_age=3600, secure=false, http_only=false }).
 -record(header, { name, value }).
 -record(response, { status_code=200, headers=[], cookies=[], data=[] }).
 

--- a/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
@@ -239,9 +239,13 @@ prepare_cookies(Req, Cookies) ->
         %% sure it's something usable, so let's just use binary
         Name = simple_bridge_util:to_binary(C#cookie.name),
         Value = simple_bridge_util:to_binary(C#cookie.value),
-        Path = C#cookie.path,
-        SecsToLive = C#cookie.minutes_to_live * 60,
-        Options = [{path, Path}, {max_age, SecsToLive}],
+        Options = [
+                   {domain, C#cookie.domain},
+                   {path, C#cookie.path},
+                   {max_age, C#cookie.max_age},
+                   {secure, C#cookie.secure},
+                   {http_only, C#cookie.http_only}
+                  ],
         cowboy_req:set_resp_cookie(Name, Value, Options, R)
     end, Req, Cookies).
 

--- a/src/inets_bridge_modules/inets_simple_bridge.erl
+++ b/src/inets_bridge_modules/inets_simple_bridge.erl
@@ -145,7 +145,7 @@ build_response(Req, Res) ->
 
 create_cookie_header(Cookie) ->
     SecondsToLive = Cookie#cookie.max_age,
-    Expire = to_cookie_expire(SecondsToLive),
+    Expire = simple_bridge_util:make_expires_from_seconds(SecondsToLive),
     Name = Cookie#cookie.name,
     Value = Cookie#cookie.value,
 	
@@ -180,12 +180,6 @@ create_cookie_header(Cookie) ->
         end,
 	
     {"Set-Cookie", io_lib:format("~s=~s; Expires=~s~s~s~s~s", [Name, Value, Expire, SecurePart, DomainPart, PathPart, HttpOnlyPart])}.
-
-to_cookie_expire(SecondsToLive) ->
-    Seconds = calendar:datetime_to_gregorian_seconds(calendar:local_time()),
-    DateTime = calendar:gregorian_seconds_to_datetime(Seconds + SecondsToLive),
-    httpd_util:rfc1123_date(DateTime).
-
 
 % Inets wants some headers as lowercase atoms, and the rest as lists. So let's fix these up.
 massage(Header) when is_binary(Header) ->

--- a/src/inets_bridge_modules/inets_simple_bridge.erl
+++ b/src/inets_bridge_modules/inets_simple_bridge.erl
@@ -162,14 +162,14 @@ create_cookie_header(Cookie) ->
             undefined ->
                 "";
             Domain ->
-                ["; Domain=", quote(Domain)]
+                ["; Domain=", Domain]
         end,
     PathPart =
         case Cookie#cookie.path of
             undefined ->
                 "";
             Path ->
-                ["; Path=", quote(Path)]
+                ["; Path=", Path]
         end,
     HttpOnlyPart =
         case Cookie#cookie.http_only of

--- a/src/mochiweb_bridge_modules/mochiweb_simple_bridge.erl
+++ b/src/mochiweb_bridge_modules/mochiweb_simple_bridge.erl
@@ -150,8 +150,13 @@ build_response(Req, Res) ->
 
 
 create_cookie_header(Cookie) ->
-    SecondsToLive = Cookie#cookie.minutes_to_live * 60,
     Name = Cookie#cookie.name,
     Value = Cookie#cookie.value,
-    Path = Cookie#cookie.path,
-    mochiweb_cookies:cookie(Name, Value, [{path, Path}, {max_age, SecondsToLive}]).
+    Options = [
+               {domain, Cookie#cookie.domain},
+               {path, Cookie#cookie.path},
+               {max_age, Cookie#cookie.max_age},
+               {secure, Cookie#cookie.secure},
+               {http_only, Cookie#cookie.http_only}
+              ],
+    mochiweb_cookies:cookie(Name, Value, Options).

--- a/src/simple_bridge_util.erl
+++ b/src/simple_bridge_util.erl
@@ -20,6 +20,7 @@
     binarize_header/1,
     is_static_path/2,
     expires/2,
+    make_expires_from_seconds/1,
     to_list/1,
     to_binary/1,
     has_header/2,

--- a/src/webmachine_bridge_modules/webmachine_simple_bridge.erl
+++ b/src/webmachine_bridge_modules/webmachine_simple_bridge.erl
@@ -151,14 +151,14 @@ create_cookie_header(Cookie) ->
             undefined ->
                 "";
             Domain ->
-                ["; Domain=", quote(Domain)]
+                ["; Domain=", Domain]
         end,
     PathPart =
         case Cookie#cookie.path of
             undefined ->
                 "";
             Path ->
-                ["; Path=", quote(Path)]
+                ["; Path=", Path]
         end,
     HttpOnlyPart =
         case Cookie#cookie.http_only of

--- a/src/webmachine_bridge_modules/webmachine_simple_bridge.erl
+++ b/src/webmachine_bridge_modules/webmachine_simple_bridge.erl
@@ -134,7 +134,7 @@ build_response(Req, Res) ->
 
 create_cookie_header(Cookie) ->
     SecondsToLive = Cookie#cookie.max_age,
-    Expire = to_cookie_expire(SecondsToLive),
+    Expire = simple_bridge_util:make_expires_from_seconds(SecondsToLive),
     Name = Cookie#cookie.name,
     Value = Cookie#cookie.value,
 	
@@ -170,7 +170,3 @@ create_cookie_header(Cookie) ->
 	
     {"Set-Cookie", io_lib:format("~s=~s; Expires=~s~s~s~s~s", [Name, Value, Expire, SecurePart, DomainPart, PathPart, HttpOnlyPart])}.
 
-to_cookie_expire(SecondsToLive) ->
-    Seconds = calendar:datetime_to_gregorian_seconds(calendar:local_time()),
-    DateTime = calendar:gregorian_seconds_to_datetime(Seconds + SecondsToLive),
-    httpd_util:rfc1123_date(DateTime).

--- a/src/webmachine_bridge_modules/webmachine_simple_bridge.erl
+++ b/src/webmachine_bridge_modules/webmachine_simple_bridge.erl
@@ -133,12 +133,42 @@ build_response(Req, Res) ->
     end.
 
 create_cookie_header(Cookie) ->
-    SecondsToLive = Cookie#cookie.minutes_to_live * 60,
+    SecondsToLive = Cookie#cookie.max_age,
     Expire = to_cookie_expire(SecondsToLive),
     Name = Cookie#cookie.name,
     Value = Cookie#cookie.value,
-    Path = Cookie#cookie.path,
-    {"Set-Cookie", io_lib:format("~s=~s; Path=~s; Expires=~s", [Name, Value, Path, Expire])}.
+	
+    % copied from mochiweb_cookies, should consider use their function instead of this one.
+    SecurePart =
+        case Cookie#cookie.secure of
+            true ->
+                "; Secure";
+            _ ->
+                ""
+        end,
+    DomainPart =
+        case Cookie#cookie.domain of
+            undefined ->
+                "";
+            Domain ->
+                ["; Domain=", quote(Domain)]
+        end,
+    PathPart =
+        case Cookie#cookie.path of
+            undefined ->
+                "";
+            Path ->
+                ["; Path=", quote(Path)]
+        end,
+    HttpOnlyPart =
+        case Cookie#cookie.http_only of
+            true ->
+                "; HttpOnly";
+            _ ->
+                ""
+        end,
+	
+    {"Set-Cookie", io_lib:format("~s=~s; Expires=~s~s~s~s~s", [Name, Value, Expire, SecurePart, DomainPart, PathPart, HttpOnlyPart])}.
 
 to_cookie_expire(SecondsToLive) ->
     Seconds = calendar:datetime_to_gregorian_seconds(calendar:local_time()),

--- a/src/yaws_bridge_modules/yaws_simple_bridge.erl
+++ b/src/yaws_bridge_modules/yaws_simple_bridge.erl
@@ -244,8 +244,3 @@ create_cookie(Cookie) ->
                {http_only, Cookie#cookie.http_only}
               ],
     yaws_api:set_cookie(Name, Value, Options).
-
-to_cookie_expire(SecondsToLive) ->
-    Seconds = calendar:datetime_to_gregorian_seconds(calendar:local_time()),
-    DateTime = calendar:gregorian_seconds_to_datetime(Seconds + SecondsToLive),
-    httpd_util:rfc1123_date(DateTime).

--- a/src/yaws_bridge_modules/yaws_simple_bridge.erl
+++ b/src/yaws_bridge_modules/yaws_simple_bridge.erl
@@ -236,10 +236,14 @@ coalesce([H|_T]) -> H.
 create_cookie(Cookie) ->
     Name = Cookie#cookie.name,
     Value = Cookie#cookie.value,
-    Path = Cookie#cookie.path,
-    SecondsToLive = Cookie#cookie.minutes_to_live * 60,
-    Expire = to_cookie_expire(SecondsToLive),
-    yaws_api:setcookie(Name, Value, Path, Expire).
+    Options = [
+               {domain, Cookie#cookie.domain},
+               {path, Cookie#cookie.path},
+               {max_age, Cookie#cookie.max_age},
+               {secure, Cookie#cookie.secure},
+               {http_only, Cookie#cookie.http_only}
+              ],
+    yaws_api:set_cookie(Name, Value, Options).
 
 to_cookie_expire(SecondsToLive) ->
     Seconds = calendar:datetime_to_gregorian_seconds(calendar:local_time()),


### PR DESCRIPTION
cookies missed support for domain, secure and http_only options. Added across all bridges.

set_cookie/5 deprecated in favor of new set_cookie/4 (but still exported for compatibility) 
 replaced to_cookie_expire/1 with simple_bridge_util:make_expires_from_seconds/1