### PR TITLE
support for cowboy 1.1.x stream without size and chunked response 

### DIFF
--- a/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
@@ -240,6 +240,10 @@ send(Code, Headers, Cookies, Body, Req) ->
     Req3 = case Body of
         {stream, Size, Fun} -> 
             cowboy_req:set_resp_body_fun(Size, Fun, Req2);
+        {stream, Fun} ->
+            cowboy_req:set_resp_body_fun(Fun, Req2);
+        {chunked, Fun} ->
+            cowboy_req:set_resp_body_fun(chunked, Fun, Req2);
         _ ->
             cowboy_req:set_resp_body(Body, Req2)
     end,


### PR DESCRIPTION
Requires Cowboy 1.1.x
Examples:
```erlang
Bridge:set_response_data({chunked,
                              fun(Fun) ->
                                    Fun("Hello "),
                                    Fun("World"),
                                    ok
                              end}).
```
```erlang
Bridge:set_response_data({stream,
                              fun(Socket, Transport) ->
                                    Transport:send(Socket, "Hello "),
                                    Transport:send(Socket, "World"),
                                    ok
                              end}).

```
