### PR TITLE
Hotfix file multipart upload vulnerability and extend common tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ rebar.test.*.config
 /.settings/
 /.project
 .idea
-
+.rebar

--- a/src/simple_bridge_multipart.erl
+++ b/src/simple_bridge_multipart.erl
@@ -55,15 +55,18 @@ parse_multipart(Req) ->
     try
         Boundary = get_multipart_boundary(Req),
         Length = get_content_length(Req),
-        ok = crash_if_too_big(Length),
+        ok = crash_if_too_big(Length, #state{parts = []}),
         Data = get_opening_body(Req), 
         State = init_state(Req, Boundary, Length, Data),
         State1 = read_boundary(Data, State),
         {Params, Files} = process_parts(State1#state.parts),
         {ok, Params, Files}
     catch
-        throw : post_too_big -> {error, post_too_big};
-        throw : {file_too_big, FileName} -> {error, {file_too_big, FileName}}
+        throw : {Reason, ErrState} ->
+            lists:foreach(fun(Part) ->
+                file:delete(Part#sb_uploaded_file.temp_file)
+            end, convert_parts_to_files(ErrState#state.parts)),
+            {error, Reason}
     end.
 
 get_content_length(Req) ->
@@ -88,9 +91,9 @@ init_state(Req, Boundary, Length, Data) ->
         parts = []
     }.
 
-crash_if_too_big(Length) ->
+crash_if_too_big(Length, State) ->
     case Length > get_max_post_size() of
-        true  -> throw(post_too_big);
+        true  -> throw({post_too_big, State});
         false -> ok
     end.
 
@@ -165,7 +168,12 @@ read_part_value(Data, Part, State = #state { boundary=Boundary }) ->
             read_part_header(Data1, #part {}, State2);
         A when A == start_value orelse A == continue ->
             % Write the line, then continue...  
-            Part2 = update_part_with_value(Line, true, Part1),
+            Part2 =
+            try
+                update_part_with_value(Line, true, Part1)
+            catch
+                throw : Reason -> throw({Reason, State})
+            end,
             read_part_value(Data1, Part2, State1);
         eof ->
             update_state_with_part(Part1, State1)
@@ -204,14 +212,19 @@ get_next_line(Data, Part, State)    -> get_next_line(Data, <<>>, Part, State).
 get_next_line(<<?NEWLINE, Data/binary>>, Acc, Part, State) -> {<<Acc/binary>>, Data, Part, State};
 get_next_line(<<C, Data/binary>>, Acc, Part, State) -> get_next_line(Data, <<Acc/binary, C>>, Part, State);
 get_next_line(Data, Acc, Part, State) when Data == undefined orelse Data == <<>> ->
-    {Data1, State1} = read_chunk(State),
-
-    % We don't want Acc to grow too big, so if we have more than ?CHUNKSIZE 
-    % data already read, then flush it to the current part.
-    {Acc1, Part1} = case Part /= undefined andalso size(Acc) > ?CHUNKSIZE of
-                        true -> {<<>>, update_part_with_value(Acc, false, Part)};
-                        false -> {Acc, Part}
-                    end,
+    {Data1, State1, Acc1, Part1} =
+    try
+        {TmpData1, TmpState1} = read_chunk(State),
+        % We don't want Acc to grow too big, so if we have more than ?CHUNKSIZE
+        % data already read, then flush it to the current part.
+        {TmpAcc1, TmpPart1} = case Part /= undefined andalso size(Acc) > ?CHUNKSIZE of
+                                  true -> {<<>>, update_part_with_value(Acc, false, Part)};
+                                  false -> {Acc, Part}
+                              end,
+        {TmpData1, TmpState1, TmpAcc1, TmpPart1}
+    catch
+        throw : Reason -> throw({Reason, State})
+    end,
     % it into a part.
     get_next_line(Data1, Acc1, Part1, State1).
 
@@ -219,7 +232,7 @@ read_chunk(State = #state { req=Req, length=Length, bytes_read=BytesRead }) ->
     BytesToRead = lists:min([Length - BytesRead, ?CHUNKSIZE]),
     Data = sbw:recv_from_socket(BytesToRead, ?IDLE_TIMEOUT, Req),
     NewBytesRead = BytesRead + size(Data),
-    ok=crash_if_too_big(NewBytesRead),
+    ok=crash_if_too_big(NewBytesRead, State),
     {Data, State#state { bytes_read=NewBytesRead }}.
 
 interpret_line(Line, Boundary) ->

--- a/test/app.config.src
+++ b/test/app.config.src
@@ -43,11 +43,11 @@
         %% FILE UPLOAD SETTINGS
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-        {max_post_size, 100},
+        {max_post_size, 3},
         %% No multipart request greater than above will be accepted. Units are
         %% MB
         
-        {max_file_size, 100},
+        {max_file_size, 2},
         %% No single uploaded file will be accepted greater than  the above.
         %% Units are MB.
 

--- a/test/simple_bridge_multipart_SUITE.erl
+++ b/test/simple_bridge_multipart_SUITE.erl
@@ -1,0 +1,124 @@
+-module(simple_bridge_multipart_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+% Override with config variable {scratch_dir, Directory}
+-define (SCRATCH_DIR, "./scratch").
+
+-export([
+    all/0,
+    groups/0,
+    init_per_group/2,
+    end_per_group/2,
+    end_per_testcase/2
+]).
+
+-export([
+    post_mutlipart/1,
+    post_mutlipart_post_too_big/1,
+    post_mutlipart_file_too_big/1
+]).
+
+all() -> [{group, multipart}].
+
+groups() -> [
+    {multipart,
+        [sequence, {repeat, 1}],
+        [post_mutlipart, post_mutlipart_post_too_big, post_mutlipart_file_too_big]
+    }].
+
+init_per_group(_Group, Config) ->
+    inets:start(),
+    application:start(simple_bridge),
+    Config.
+
+end_per_group(_Group, Config) ->
+    inets:stop(),
+    application:stop(simple_bridge),
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    lists:foreach(fun(File) -> file:delete(File) end, filelib:wildcard("./scratch/*")).
+
+post_mutlipart(Config) ->
+    BinStream1 = crypto:strong_rand_bytes(1024000),
+    BinStream2 = crypto:strong_rand_bytes(2048000),
+    Data1 = binary_to_list(BinStream1),
+    Data2 = binary_to_list(BinStream2),
+    Files = [{data, "data1", Data1}, {data, "data2", Data2}],
+
+    {UploadedFiles, Errors} = binary_to_term(post_mutlipart("uploaded_files", Files)),
+
+    2 = length(UploadedFiles),
+    none = Errors,
+    2 = length(get_all_files_from_scratch_dir()),
+    lists:foreach(fun({AtomFieldName, FileName, FileContent}) ->
+        FieldName = atom_to_list(AtomFieldName),
+        BinaryFileContent = list_to_binary(FileContent),
+        ByteSize = byte_size(BinaryFileContent),
+        File = proplists:get_value(FileName, UploadedFiles),
+        {ok, Binary} = file:read_file(sb_uploaded_file:temp_file(File)),
+
+        ByteSize = sb_uploaded_file:size(File),
+        FieldName = sb_uploaded_file:field_name(File),
+        FileName = sb_uploaded_file:original_name(File),
+        Binary = BinaryFileContent
+    end, Files).
+
+post_mutlipart_post_too_big(Config) ->
+    BinStream1 = crypto:strong_rand_bytes(2048000),
+    BinStream2 = crypto:strong_rand_bytes(2048000),
+    Data1 = binary_to_list(BinStream1),
+    Data2 = binary_to_list(BinStream2),
+    Files = [{data, "data1", Data1}, {data, "data2", Data2}],
+
+    {[], post_too_big} = binary_to_term(post_mutlipart("uploaded_files", Files)),
+    [] = get_all_files_from_scratch_dir().
+
+post_mutlipart_file_too_big(_) ->
+    BinStream1 = crypto:strong_rand_bytes(1024),
+    BinStream2 = crypto:strong_rand_bytes(3072000),
+    Data1 = binary_to_list(BinStream1),
+    Data2 = binary_to_list(BinStream2),
+    Files = [{data, "data1", Data1}, {data, "data2", Data2}, {data, "data3", Data1}],
+
+    {[], {file_too_big,"data2"}} = binary_to_term(post_mutlipart("uploaded_files", Files)),
+    [] = get_all_files_from_scratch_dir().
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+get_all_files_from_scratch_dir() ->
+    filelib:wildcard(filename:absname_join(simple_bridge_util:get_scratch_dir(?SCRATCH_DIR), "*")).
+
+%% Based on http://stackoverflow.com/a/39284072
+format_multipart_formdata(Boundary, Fields, Files) ->
+    FieldParts = lists:map(fun({FieldName, FieldContent}) ->
+        [lists:concat(["--", Boundary]),
+         lists:concat(["Content-Disposition: form-data; name=\"",atom_to_list(FieldName),"\""]),
+         "", FieldContent]
+    end, Fields),
+
+    FieldParts2 = lists:append(FieldParts),
+
+    FileParts = lists:map(fun({FieldName, FileName, FileContent}) ->
+        [lists:concat(["--", Boundary]),
+         lists:concat(["Content-Disposition: form-data; name=\"",atom_to_list(FieldName),"\"; filename=\"",FileName,"\""]),
+         lists:concat(["Content-Type: ", "application/octet-stream"]), "", FileContent]
+    end, Files),
+
+    FileParts2 = lists:append(FileParts),
+    EndingParts = [lists:concat(["--", Boundary, "--"]), ""],
+    Parts = lists:append([FieldParts2, FileParts2, EndingParts]),
+    string:join(Parts, "\r\n").
+
+post_mutlipart(Path, Files) ->
+    Boundary = "------WebKitFormBoundaryUscTgwn7KiuepIr1",
+    ReqBody = format_multipart_formdata(Boundary, [], Files),
+    ContentType = lists:concat(["multipart/form-data; boundary=", Boundary]),
+    ReqHeader = [{"Content-Length", integer_to_list(length(ReqBody))}],
+
+    {ok, {_, _, Val}} = httpc:request(post,{"http://127.0.0.1:8000/" ++ Path, ReqHeader, ContentType, ReqBody},
+                                      [], [{body_format, binary}]),
+    Val.

--- a/test/simple_bridge_test_handler.erl
+++ b/test/simple_bridge_test_handler.erl
@@ -18,6 +18,7 @@ run("/uri", Bridge) -> simple_call(uri, Bridge);
 run("/request_method_get", Bridge) -> simple_call(request_method, Bridge);
 run("/request_method_post", Bridge) -> simple_call(request_method, Bridge);
 run("/request_body", Bridge) -> simple_call(request_body, Bridge);
+run("/uploaded_files", Bridge) -> get_uploaded_files(Bridge);
 run("/query_params", Bridge) -> simple_call(query_params, Bridge);
 run("/post_params", Bridge) -> simple_call(post_params, Bridge);
 run("/cookie", Bridge) -> do_cookies(Bridge);
@@ -28,6 +29,13 @@ simple_call(Call, Bridge) ->
 	Val = sbw:Call(Bridge),
 	Body = io_lib:format("~p", [Val]),
     sbw:set_response_data(Body, Bridge).
+
+get_uploaded_files(Bridge) ->
+    Files = sbw:post_files(Bridge),
+    Errors = sbw:error(Bridge),
+    sbw:set_response_data(term_to_binary({lists:map(fun(File) ->
+        {sb_uploaded_file:original_name(File), File}
+    end, Files), Errors}), Bridge).
 
 do_cookies(Bridge) ->
     Type = sbw:query_param(type, Bridge),


### PR DESCRIPTION
After raising an error while trying to upload multiple files over the multipart endpoint, all successful uploaded and temporary saved files will now be cleaned up correctly from scratch folder to prevent orphans and attacks that could easily fill up the disk. This is done by extending all exceptions with the last valid state in order to be able to access and delete all successful uploaded files so far.

The additional test suite `simple_bridge_multipart_SUITE` does reflect the possible vulnerability with the `post_mutlipart_file_too_big/1` test case, while `post_mutlipart/1` and `post_mutlipart_post_too_big/1` represents compliance test cases. I think it would be nice to also extend them with some property based tests through proper/quickcheck or some other alternatives. 

IMHO this PR should rather be seen as a hotfix and I think `simple_bridge_multipart.erl` and corresponding files should rather be refactored to not use that much of exception handling as the main control flow. It was hard to survey all possible method calls which could pass-through an exception in order to catch and extend them with the last valid state. Maybe some monadic handling as a combination of a state and error monad could help out - see [do-notation with erlando](https://github.com/rabbitmq/erlando#do) for more informations.