### PR TITLE
Fix dialyzer errors.

### DIFF
--- a/src/sbw.erl
+++ b/src/sbw.erl
@@ -323,7 +323,7 @@ find_param_group(Param, Default, ParamList) when is_binary(Param) ->
         L -> L
     end;
 find_param_group(Param, Default, ParamList) when is_list(Param); is_atom(Param) ->
-    Param1 = simple_bridge_util:to_list(Param),
+    Param1 = simple_bridge_util:to_binary(Param),
     ResultList = find_param_group(Param1, Default, ParamList),
     [simple_bridge_util:to_list(V) || V <- ResultList].
 

--- a/src/simple_bridge.erl
+++ b/src/simple_bridge.erl
@@ -102,9 +102,7 @@ make_nocatch(Module, RequestData) ->
             %% lookup
             sbw:cache_post_params(Bridge);
         {error, Error} -> 
-            Bridge:set_error(Error);
-        Other -> 
-            throw({unexpected, Other})
+            Bridge:set_error(Error)
     end.
 
 

--- a/src/simple_bridge_util.erl
+++ b/src/simple_bridge_util.erl
@@ -293,7 +293,7 @@ expires(seconds,X) when is_integer(X) ->
 
 -spec make_expires_from_seconds(integer()) -> string().
 make_expires_from_seconds(Seconds) ->
-    {NowMegaSec,NowSec,_} = now(),
+    {NowMegaSec,NowSec,_} = os:timestamp(),
     ExpiresDate = calendar:now_to_local_time({NowMegaSec,NowSec+Seconds,0}),
     httpd_util:rfc1123_date(ExpiresDate).
 

--- a/src/simple_bridge_websocket.erl
+++ b/src/simple_bridge_websocket.erl
@@ -115,7 +115,7 @@ cancel_pong_timer(TRef) ->
 
 hijack_request_fail(Bridge) ->
     Bridge2 = sbw:set_status_code(400, Bridge),
-    Bridge3 = sbw:set_header(Bridge2, "Sec-Websocket-Version", ?WS_VERSION),
+    Bridge3 = sbw:set_header("Sec-Websocket-Version", ?WS_VERSION, Bridge2),
     Bridge4 = sbw:set_response_data(["Invalid Websocket Upgrade Request. Please use Websocket version ",?WS_VERSION], Bridge3),
     Bridge4.
 

--- a/src/simple_bridge_websocket.erl
+++ b/src/simple_bridge_websocket.erl
@@ -11,6 +11,8 @@
 
         %% Exported for code-reloading
         websocket_loop/8
+
+        , dialyzer_fix/0
     ]).
 
 %-compile(export_all).
@@ -498,3 +500,6 @@ is_utf8(<< 2#11110100:8, 2#10:2, High:6, _/bits >>) when High >= 2#10000 ->
 %% Invalid.
 is_utf8(_) ->
         false.
+
+dialyzer_fix() ->
+    apply_mask(<<15:32>>, 0).


### PR DESCRIPTION
This pull request contains a number of small fixes for simple_bridge 2.0.1 revealed by dialyzer, in order of controversy.

The first two commits fix genuine bugs that dialyzer uncovered: an incorrect conversion, and a function call with the arguments in the wrong order.

The third commit converts a `now()` call to `os:timestamp()`. Dialyzer warns that `now` is deprecated, and the `os:timestamp` call is equivalent (and faster).

The fourth commit removes a case clause that dialyzer says is unnecessary. I think dialyzer is correct, but even if it isn't the only difference is a slightly different error is returned from `simple_bridge:inner_make/2`.

The fifth commit silences another dialyzer warning, where is says that a function head is never matched. I believe that dialyzer is right, but rather than removing the code, I added a call from a dummy function to silence the warning.

Feel free to take as many or as few of these commits as you want, and to modify them as you see fit.