### PR TITLE
replaced get_stacktrace with new catch semantics

### DIFF
--- a/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
@@ -45,8 +45,8 @@ get_key(ReqKey) ->
     try
         RequestCache = #request_cache{request = Req} = cowboy_request_server:get(ReqKey),
         {RequestCache, Req}
-    catch E:T ->
-        error_logger:info_msg("~p:~p~n~p", [E, T, erlang:get_stacktrace()])
+    catch E:T:ST ->
+        error_logger:info_msg("~p:~p~n~p", [E, T, ST])
     end.
 
 put_key(ReqKey, NewRequestCache) ->

--- a/src/mochiweb_bridge_modules/mochiweb_simple_bridge_anchor.erl
+++ b/src/mochiweb_bridge_modules/mochiweb_simple_bridge_anchor.erl
@@ -29,5 +29,5 @@ loop(Req) ->
         end
     catch
         exit:normal -> exit(normal);
-        T:E -> error_logger:error_msg("Error: ~p:~p~nStacktrace: ~p~n",[T, E, erlang:get_stacktrace()])
+        T:E:ST -> error_logger:error_msg("Error: ~p:~p~nStacktrace: ~p~n",[T, E, ST])
     end.

--- a/src/simple_bridge.erl
+++ b/src/simple_bridge.erl
@@ -84,8 +84,8 @@ make_bridge_module(BridgeType) ->
 inner_make(Module, RequestData) ->
     try
         make_nocatch(Module, RequestData)
-    catch Type : Error ->
-        error_logger:error_msg("Error in simple_bridge:make/2 - ~p - ~p~n~p", [Type, Error, erlang:get_stacktrace()]),
+    catch Type : Error : Stacktrace ->
+        error_logger:error_msg("Error in simple_bridge:make/2 - ~p - ~p~n~p", [Type, Error, Stacktrace]),
         erlang:Type(Error)
     end.
 

--- a/src/simple_bridge_handler_sample.erl
+++ b/src/simple_bridge_handler_sample.erl
@@ -12,8 +12,8 @@ run(Bridge) ->
     try
         Bridge2 = Bridge:set_response_data(body(Bridge)),
         Bridge2:build_response()
-    catch E:C ->
-        error_logger:error_msg("~p:~p: ~p",[E, C, erlang:get_stacktrace()]),
+    catch E:C:ST ->
+        error_logger:error_msg("~p:~p: ~p",[E, C, ST]),
         exit("Error building response")
     end.
 


### PR DESCRIPTION
Hi!  With `warnings_as_errors` set, the depreciation warning for erlang:get_stacktrace/0 prevents compilation with Erlang 21.  I *think* this patch resolves that issue correctly.  (`make test` returns the same results, which is to say "14 ok, 1 failed, 1 skipped of 16 test cases."