### PR TITLE
Cowboy 2.x Support

### DIFF
--- a/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
@@ -44,8 +44,8 @@ get_key(ReqKey) ->
     try
         RequestCache = #request_cache{request = Req} = cowboy_request_server:get(ReqKey),
         {RequestCache, Req}
-    catch Class:Reason:Stacktrace  ->
-        error_logger:info_msg("~p:~p~n~p", [Class, Reason, Stacktrace])
+    catch E:T  ->
+        error_logger:info_msg("~p:~p~n~p", [E, T, erlang:get_stacktrace()])
     end.
 
 put_key(ReqKey, NewRequestCache) ->

--- a/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
@@ -44,8 +44,8 @@ get_key(ReqKey) ->
     try
         RequestCache = #request_cache{request = Req} = cowboy_request_server:get(ReqKey),
         {RequestCache, Req}
-    catch E:T ->
-        error_logger:info_msg("~p:~p~n~p", [E, T, erlang:get_stacktrace()])
+    catch Class:Reason:Stacktrace  ->
+        error_logger:info_msg("~p:~p~n~p", [Class, Reason, Stacktrace])
     end.
 
 put_key(ReqKey, NewRequestCache) ->

--- a/src/cowboy_bridge_modules/cowboy_simple_bridge_sup.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge_sup.erl
@@ -33,12 +33,10 @@ init([]) ->
     Dispatch = generate_dispatch(),
     io:format("Using Cowboy Dispatch Table:~n  ~p~n",[Dispatch]),
 
-    Opts = [
-        {env, [{dispatch, Dispatch}]},
-        {max_keepalive, 100}
-    ],
+    Opts = #{env => #{dispatch => Dispatch},
+             max_keepalive => 100},
 
-    cowboy:start_http(http, 100, [{ip, IP}, {port, Port}], Opts),
+    cowboy:start_clear(http, [{ip, IP}, {port, Port}], Opts),
 
     {ok, { {one_for_one, 5, 10}, []}}.
 

--- a/src/mochiweb_bridge_modules/mochiweb_simple_bridge_anchor.erl
+++ b/src/mochiweb_bridge_modules/mochiweb_simple_bridge_anchor.erl
@@ -29,5 +29,5 @@ loop(Req) ->
         end
     catch
         exit:normal -> exit(normal);
-        T:E -> error_logger:error_msg("Error: ~p:~p~nStacktrace: ~p~n",[T, E, erlang:get_stacktrace()])
+        T:E:S -> error_logger:error_msg("Error: ~p:~p~nStacktrace: ~p~n",[T, E, S])
     end.

--- a/src/mochiweb_bridge_modules/mochiweb_simple_bridge_anchor.erl
+++ b/src/mochiweb_bridge_modules/mochiweb_simple_bridge_anchor.erl
@@ -29,5 +29,5 @@ loop(Req) ->
         end
     catch
         exit:normal -> exit(normal);
-        T:E:S -> error_logger:error_msg("Error: ~p:~p~nStacktrace: ~p~n",[T, E, S])
+        T:E -> error_logger:error_msg("Error: ~p:~p~nStacktrace: ~p~n",[T, E, erlang:get_stacktrace()])
     end.

--- a/src/sbw.erl
+++ b/src/sbw.erl
@@ -146,7 +146,7 @@ cache_query_params(Wrapper) ->
     Mod = Wrapper#sbw.mod,
     Req = Wrapper#sbw.req,
     Wrapper#sbw{
-      query_params=[normalize_param({K,V}) || {K,V} <- Mod:query_params(Req)],
+      query_params=[normalize_param({K,V}) || {K,V} <- Mod:query_params(Req)]
     }.
 
 

--- a/src/simple_bridge.erl
+++ b/src/simple_bridge.erl
@@ -84,8 +84,8 @@ make_bridge_module(BridgeType) ->
 inner_make(Module, RequestData) ->
     try
         make_nocatch(Module, RequestData)
-    catch Type : Error : Stacktrace ->
-        error_logger:error_msg("Error in simple_bridge:make/2 - ~p - ~p~n~p", [Type, Error, Stacktrace]),
+    catch Type : Error ->
+        error_logger:error_msg("Error in simple_bridge:make/2 - ~p - ~p~n~p", [Type, Error, erlang:get_stacktrace()]),
         erlang:Type(Error)
     end.
 

--- a/src/simple_bridge.erl
+++ b/src/simple_bridge.erl
@@ -84,8 +84,8 @@ make_bridge_module(BridgeType) ->
 inner_make(Module, RequestData) ->
     try
         make_nocatch(Module, RequestData)
-    catch Type : Error ->
-        error_logger:error_msg("Error in simple_bridge:make/2 - ~p - ~p~n~p", [Type, Error, erlang:get_stacktrace()]),
+    catch Type : Error : Stacktrace ->
+        error_logger:error_msg("Error in simple_bridge:make/2 - ~p - ~p~n~p", [Type, Error, Stacktrace]),
         erlang:Type(Error)
     end.
 

--- a/src/simple_bridge_handler_sample.erl
+++ b/src/simple_bridge_handler_sample.erl
@@ -12,8 +12,8 @@ run(Bridge) ->
     try
         Bridge2 = Bridge:set_response_data(body(Bridge)),
         Bridge2:build_response()
-    catch E:C ->
-        error_logger:error_msg("~p:~p: ~p",[E, C, erlang:get_stacktrace()]),
+    catch E:C:S ->
+        error_logger:error_msg("~p:~p: ~p",[E, C, S]),
         exit("Error building response")
     end.
 

--- a/src/simple_bridge_handler_sample.erl
+++ b/src/simple_bridge_handler_sample.erl
@@ -12,8 +12,8 @@ run(Bridge) ->
     try
         Bridge2 = Bridge:set_response_data(body(Bridge)),
         Bridge2:build_response()
-    catch E:C:S ->
-        error_logger:error_msg("~p:~p: ~p",[E, C, S]),
+    catch E:C ->
+        error_logger:error_msg("~p:~p: ~p",[E, C, erlang:get_stacktrace()]),
         exit("Error building response")
     end.
 


### PR DESCRIPTION
1) Adapted to latest Cowboy 2.x (2.4) APIs, new maps structure and case sensitive Headers
2) For backward compability, needed Erlang 21 adaptations of erlang:get_stacktrace() will be handled by a separate parse transform