### PR TITLE
fix parsing of post req for non default content types

### DIFF
--- a/src/simple_bridge.erl
+++ b/src/simple_bridge.erl
@@ -103,10 +103,17 @@ make_nocatch(Module, RequestData) ->
             %% Post Params are read from the multipart parsing
             sbw:set_multipart(PostParams, Files, Bridge);
         {ok, not_multipart} -> 
-            %% But if it's not a multipart post, then we need to manually tell
+            %% If it's not a multipart post but application/x-www-urlencoded then we need to manually tell
             %% simple bridge to cache the post params in the wrapper for quick
             %% lookup
-            sbw:cache_post_params(Bridge);
+            ContentType =  sbw:header_lower(content_type, Bridge),
+            case ContentType of
+                "application/x-www-urlencoded" ->
+                    sbw:cache_post_params(Bridge);
+                undefined -> 
+                    sbw:cache_post_params(Bridge);
+                _ -> Bridge
+            end;
         {error, Error} -> 
             error_logger:error_msg("Error in Multipart: ~p",[Error]),
             sbw:set_error(Error, Bridge)


### PR DESCRIPTION
sbw:cache_post_params should not be called if the requests content-type is not application/x-www-urlencoded.
At least in case of cowboy it results in a crash if the binary contains unparsable content.