### PR TITLE
YAWS: Support if ssl is found instead as well as sslsocket

### DIFF
--- a/src/yaws_bridge_modules/yaws_simple_bridge.erl
+++ b/src/yaws_bridge_modules/yaws_simple_bridge.erl
@@ -32,6 +32,7 @@ init(Req) ->
 protocol(Arg) -> 
     case yaws_api:arg_clisock(Arg) of
         S when is_tuple(S), element(1, S) =:= sslsocket -> https;
+        S when is_tuple(S), element(1, S) =:= ssl -> https;
         _ -> http
     end.
 


### PR DESCRIPTION
Hi Jesse, 

I am now running 22/23 erlang with yaws master branch. 

I have not had this issue before and run a custom module of this previously; but it is not giving me the correct protocol; which determine what http headers I return. 

Manual tests have shown this PR is correct; busy building a release and will remove the PR if not correct. 

Regards,
Stuart
