### PR TITLE
Add `noreply` clause to `cowboy` anchor

### DIFF
--- a/src/cowboy_bridge_modules/cowboy_simple_bridge_anchor.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge_anchor.erl
@@ -97,5 +97,7 @@ massage_reply({noreply, NewState}, WSState) ->
     {ok, WSState#ws_state{state=NewState}};
 massage_reply({remote, _Reason}, WSState) ->
     {stop, WSState};
+massage_reply(noreply, WSState) ->
+    {ok, WSState};
 massage_reply(stop, WSState) ->
     {stop, WSState}.


### PR DESCRIPTION
Running `cowboy` at `{tag, "2.8.0"}` I found that the websocket connection
routinely crashed every so many seconds. By tracing the error message I found a
missing clause on `massage_reply` where `noreply` came without any updated
state.

In this patch I'm adding that clause which passes the existing state without
any changes. Beyond the tactical fix I'm largely ignorant on how this works
or how it ought to be fixed or even if the problem is broader support for
newer Cowboy versions.

@choptastic by adding this we're able to use `nitrogen` without a constant
crashing web socket. I'm happy to put more effort into this PR if you have
some guidance. I'm not sure this could make things worse in any way, so we'd
also be happy as clams if we had this merged in even without digging deeper.