### PR TITLE
Add `simple_bridge:host/1` callback

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -225,6 +225,8 @@ application. A single bridge will do, pig.
 
 ### Request Bridge Interface
 
+  * **sbw:protocol(Bridge)** - returns request protocol as atom 'http' or 'https'.
+  * **sbw:host(Bridge)** - returns the host value for the request, or the root host from the `x-forwarded-for` header.
   * **sbw:request_method(Bridge)** - returns atom 'GET', 'POST', 'HEAD', etc.
   * **sbw:path(Bridge)** - returns the requested path and file (string)
   * **sbw:peer_ip(Bridge)** - returns the client's IP address in tuple format

--- a/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
@@ -12,6 +12,7 @@
 -export([
         init/1,
         protocol/1,
+        host/1,
         request_method/1,
         path/1,
         uri/1,
@@ -68,6 +69,11 @@ protocol(ReqKey) ->
         <<"https">> -> https
     end.
 
+host(ReqKey) ->
+    {_RequestCache, Req} = get_key(ReqKey),
+    % @TODO: Could x-forwarded-for be the better value here if it exists?
+    Host = cowboy_req:host(Req),
+    simple_bridge_util:to_list(Host).
 
 request_method(ReqKey) ->
     {_RequestCache, Req} = get_key(ReqKey),

--- a/src/inets_bridge_modules/inets_simple_bridge.erl
+++ b/src/inets_bridge_modules/inets_simple_bridge.erl
@@ -10,6 +10,7 @@
 -export ([
         init/1,
         protocol/1,
+        host/1,
         request_method/1,
         path/1,
         uri/1,
@@ -40,7 +41,13 @@ protocol(Req) ->
         _ -> http
     end.
 
-request_method(Req) -> 
+host(Req) ->
+    Headers = headers(Req),
+    Host = proplists:get_value("host", Headers),
+    XForwardedFor = proplists:get_value("x-forwarded-for", Headers),
+    simple_bridge_util:infer_host(Req#mod.absolute_uri, Host, XForwardedFor).
+
+request_method(Req) ->
     list_to_atom(Req#mod.method).
 
 path(Req) -> 

--- a/src/mochiweb_bridge_modules/mochiweb_simple_bridge.erl
+++ b/src/mochiweb_bridge_modules/mochiweb_simple_bridge.erl
@@ -9,6 +9,7 @@
 -export ([
     init/1,
     protocol/1,
+    host/1,
     request_method/1, 
     path/1,
     uri/1,
@@ -51,6 +52,12 @@ init(Req) ->
 
 protocol(Req) ->
     mochiweb_request:get(scheme, Req).
+
+host(Req) ->
+    Headers = mochiweb_request:get(headers, Req),
+    Host = mochiweb_headers:get_value("host", Headers),
+    XForwardedFor = mochiweb_headers:get_value("x-forwarded-for", Headers),
+    simple_bridge_util:infer_host(undefined, Host, XForwardedFor).
 
 request_method(Req) -> 
     mochiweb_request:get(method, Req).

--- a/src/sbw.erl
+++ b/src/sbw.erl
@@ -14,6 +14,7 @@
     set_error/2,
     cache_post_params/1,
     protocol/1,
+    host/1,
     path/1,
     uri/1,
     peer_ip/1,
@@ -198,6 +199,7 @@ error(Wrapper) ->
         (Wrapper#sbw.mod):FunctionName(Wrapper#sbw.req)).
 
 ?PASSTHROUGH(protocol).
+?PASSTHROUGH(host).
 ?PASSTHROUGH(path).
 ?PASSTHROUGH(uri).
 ?PASSTHROUGH(peer_ip).

--- a/src/simple_bridge.erl
+++ b/src/simple_bridge.erl
@@ -24,6 +24,7 @@
 -callback uri(req())                         -> string().
 -callback path(req())                        -> string().
 -callback headers(req())                     -> [{key(), value()}] | map().
+-callback host(req())                        -> string().
 -callback query_params(req())                -> [{key(), value()}].
 -callback post_params(req())                 -> [{key(), value()}].
 -callback peer_ip(req())                     -> ipv4() | ipv8().

--- a/src/webmachine_bridge_modules/webmachine_simple_bridge.erl
+++ b/src/webmachine_bridge_modules/webmachine_simple_bridge.erl
@@ -11,6 +11,7 @@
 -export ([
         init/1,
         protocol/1,
+        host/1,
         request_method/1, 
         path/1, 
         uri/1,
@@ -36,6 +37,14 @@ init(Req) ->
 
 protocol(Req) ->
     wrq:scheme(Req).
+
+host(Req) ->
+  % @TODO: Can we get the absolute URI without all this?
+  BaseURI = wrq:base_uri(Req),
+  MochiHeaders = wrq:req_headers(Req),
+  Host = mochiweb_headers:get_value("host", MochiHeaders),
+  XForwardedFor = mochiweb_headers:get_value("x-forwarded-for", MochiHeaders),
+  simple_bridge_util:infer_host(BaseURI, Host, XForwardedFor).
 
 request_method(Req) -> 
     wrq:method(Req).

--- a/src/yaws_bridge_modules/yaws_simple_bridge.erl
+++ b/src/yaws_bridge_modules/yaws_simple_bridge.erl
@@ -11,7 +11,7 @@
 -include("simple_bridge.hrl").
 -export ([
     init/1,
-    request_method/1, protocol/1, path/1, uri/1,
+    request_method/1, protocol/1, host/1, path/1, uri/1,
     peer_ip/1, peer_port/1,
     headers/1, cookies/1,
     native_header_type/0,
@@ -35,6 +35,14 @@ protocol(Arg) ->
         S when is_tuple(S), element(1, S) =:= ssl -> https;
         _ -> http
     end.
+
+host(Arg) ->
+    % @TODO: Can we get the full URL without parsing and printing or importing an internal yaws .hrl?
+    URL = yaws_api:request_url(Arg),
+    [_Scheme, Host, _Port, _Path, _QueryPart] = yaws_api:format_url(URL),
+    Headers = yaws_api:arg_headers(Arg),
+    XForwardedFor = yaws_api:headers_x_forwarded_for(Headers) ,
+    simple_bridge_util:infer_host(undefined, Host, XForwardedFor).
 
 request_method(Arg) ->
     yaws_api:http_request_method(yaws_api:arg_req(Arg)).


### PR DESCRIPTION
## Status

I know nothing about what I'm doing here and I didn't test any of this. What I've put together represents a draft idea for supporting a new interface to get the host data out of `simple_bridge`. I've only used `cowboy` and wouldn't say I'm an expert on how it operates or handles the `host` value (though I hope to experiment and test to find out).

Would like some review of the general idea and approach. See #79 for a motivating example: `nitrogen_core` crashes when calling `wf:url()` on a `cowboy` TLS server because it doesn't provide a `host` HTTP header. A cursory glance around the web turns up that Golang's standard library lifts the `host` header out of the `headers` and into a request property there as well. some part of Python's `requests` might omit the `Host` HTTP header in some cases but I didn't look deep enough to confirm.

## Description

The `host` value for a given request may depend on multiple values:
 - the `Host` HTTP header
 - the `X-Forwarded-For` HTTP header
 - the absolute URI for the request
 - the `Host` property of the request set by the HTTP server

When applications rely on getting this value diretly through the HTTP headers they may run into issues with this being undefined or wrong. Possible scenarios may include:
 - pre-HTTP/1.1 requests without an explicit `Host` HTTP header
 - TLS requests when the underlying web server doesn't set a header from the initial `:authority` parameter.
 - proxied requests with an `X-Forwarded-For` HTTP header

In this patch we're adding a new `host/1` callback so that the underlying implementation can provide a proper value for the request's host, whether or not it's set as an HTTP header, and whether or not a proxy might be providing more accurate information.