### PR TITLE
Fix dialyzer erros for cowboy 2.9.0

### DIFF
--- a/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
+++ b/src/cowboy_bridge_modules/cowboy_simple_bridge.erl
@@ -162,9 +162,7 @@ recv_from_socket(_Length, _Timeout, ReqKey) ->
             Data;
         {more, Data, NewReq} ->
             put_key(ReqKey, RequestCache#request_cache{request = NewReq}),
-            Data;
-        {error, Reason} ->
-            exit({error, Reason}) %% exit(normal) instead?
+            Data
     end.
 
 
@@ -174,7 +172,7 @@ protocol_version(ReqKey) ->
     case Version of
         'HTTP/1.1' -> {1, 1};
         'HTTP/1.0' -> {1, 0};
-        {H, L} -> {H, L}
+        'HTTP/2' -> {2, 0}
     end.
 
 %% RESPONSE


### PR DESCRIPTION
simple_bridge/src/cowboy_bridge_modules/cowboy_simple_bridge.erl

Line 117 Column 9:
   The variable _ can never match since previous clauses completely covered the type #{binary()=>binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | [])}
Line 166 Column 9: The pattern {'error', Reason} can never match the type {'more',binary(),#{'body_length':='undefined' | non_neg_integer(), ... Line 177 Column 9: The pattern {H, L} can never match the type 'HTTP/2'