### PR TITLE
updated for Erlang 27

### DIFF
--- a/src/simple_bridge_websocket.erl
+++ b/src/simple_bridge_websocket.erl
@@ -16,7 +16,7 @@
 %-compile(export_all).
 -include("simple_bridge.hrl").
 
--define(else, true).
+-define(otherwise, true).
 
 -define(WS_MAGIC, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").
 -define(WS_VERSION, "13").
@@ -66,7 +66,7 @@ attempt_hijacking(Bridge, Handler) ->
                     hijack_request_fail(Bridge)
             end,
             {hijacked, HijackedBridge};
-        ?else ->
+        ?otherwise ->
             spared      %% Spared from being hijacked
     end.
 
@@ -380,10 +380,10 @@ type(?WS_BINARY) -> binary;
 type(?WS_TEXT) -> text.
 
 -define(DO_FRAMES(Mask),
-    if 
+    if
         byte_size(Data) >= PayloadLen ->
             do_frames(Fin,RSV,Op,PayloadLen,Mask,Data);
-        ?else ->
+        ?otherwise ->
             [Raw]
     end).
 


### PR DESCRIPTION
There is an issue with using `else` as a macro name in Erlang 27.0.  (I think it conflicts with `maybe` ... `else`.)

To wit:

```
#13 38.18 src/simple_bridge_websocket.erl:19:9: badly formed 'define'
#13 38.18 src/simple_bridge_websocket.erl:69:10: illegal macro call '?'else''
#13 38.18 src/simple_bridge_websocket.erl:405:16: illegal macro call '?'else''
```

This PR simply changes `?else` to `?otherwise`.